### PR TITLE
Remove FreeBSD build hacks

### DIFF
--- a/src/pspg.c
+++ b/src/pspg.c
@@ -10,12 +10,7 @@
  *
  *-------------------------------------------------------------------------
  */
-#ifdef __FreeBSD__
-#define _WITH_GETLINE
-#include <ncurses/curses.h>
-#else
 #include <curses.h>
-#endif
 #include <errno.h>
 #include <getopt.h>
 #include <stdio.h>


### PR DESCRIPTION
Please Revert FreeBSD related defines introduced in d48ad4f
I added a proper FreeBSD port and these defines are not needed anymore.