### PR TITLE
Improve Makefile to better support Debian/Ubuntu packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ pspg: src/pspg.c config.make
 	$(CC) src/pspg.c -o pspg $(CFLAGS) $(LDFLAGS) $(LDLIBS)
 
 clean:
-	rm ./pspg
+	$(RM) pspg
 	
 distclean: clean
 	$(RM) -r autom4te.cache

--- a/config.make.in
+++ b/config.make.in
@@ -9,7 +9,7 @@ datarootdir = @datarootdir@
 sysconfdir = @sysconfdir@
 
 CC = @CC@
-CFLAGS = @CFLAGS@ @COVERAGE_CFLAGS@ @DEBUG_CFLAGS@
+CFLAGS = @CFLAGS@ @COVERAGE_CFLAGS@ @DEBUG_CFLAGS@ @CURSES_CFLAGS@
 LDFLAGS = @LDFLAGS@
 LDLIBS = @LIBS@ @CURSES_LIBS@
 


### PR DESCRIPTION
Use $(RM) in clean target to avoid failing if the executable is not
present.

Add @CURSES_CFLAGS@ in config.make.inc to fix the build on Debian
Stretch with libncursesw5-dev