### PR TITLE
Define MAXPATHLEN on platforms that do not provide it

### DIFF
--- a/src/pspg.c
+++ b/src/pspg.c
@@ -31,6 +31,11 @@
 //#define COLORIZED_NO_ALTERNATE_SCREEN
 //#define DEBUG_COLORS				1
 
+/* GNU Hurd does not define MAXPATHLEN */
+#ifndef MAXPATHLEN
+#define MAXPATHLEN 4096
+#endif
+
 typedef struct LineBuffer
 {
 	int		first_row;


### PR DESCRIPTION
GNU Hurd does not define a static MAXPATHLEN because it does not have
such a limit. Define it anyway here so we can use it for buffers.

Debian hurd-i386 build log: https://buildd.debian.org/status/fetch.php?pkg=pspg&arch=hurd-i386&ver=0.5-1&stamp=1511137285&raw=0