### PR TITLE
additional keyboard sequences for xterm

### DIFF
--- a/src/pspg.c
+++ b/src/pspg.c
@@ -2092,6 +2092,7 @@ exit_search_next_bookmark:
 				break;
 
 			case 5:		/* CTRL E */
+			case 520:	/* CTRL DOWN @xterm */
 				{
 					int		max_cursor_row;
 					int		max_first_row;
@@ -2112,6 +2113,7 @@ exit_search_next_bookmark:
 				break;
 
 			case 25:	/* CTRL Y */
+			case 561:	/* CTRL UP @xterm */
 				if (first_row > 0)
 				{
 					first_row -= 1;
@@ -2250,12 +2252,14 @@ recheck_right:
 				break;
 
 			case 538:		/* CTRL HOME */
+			case 530:		/* @xterm */
 			case 'g':
 				cursor_row = 0;
 				first_row = 0;
 				break;
 
 			case 533:		/* CTRL END */
+			case 525:		/* @xterm */
 			case 'G':
 				cursor_row = desc.last_row - desc.first_data_row;
 				first_row = desc.last_row - desc.title_rows - scrdesc.main_maxy + 1;


### PR DESCRIPTION
Keyboard handling code needs some rework to recognize better modified special keys - for example alt-insert generates "\e[2;3~" under xterm (I'd like to use it for bookmarks, as an alternative to alt-k), shift-UP/DOWN returns \e[1;2A/B (suitable for moving between bookmarks, as an alternative to alt-i/j). Separate "case" for escape character (keycode 27) in switch statement makes such changes hard.

Meanwhile - fixed ctrl-home/end under xterm and added alternative ctrl-up/down (== ctrl-y/e).