### PR TITLE
Fix NCURSES_VERSION_PATCH format string

### DIFF
--- a/src/pspg.c
+++ b/src/pspg.c
@@ -2017,7 +2017,7 @@ main(int argc, char *argv[])
 
 #ifdef NCURSES_VERSION
 
-				fprintf(stdout, "ncurses version: %s, patch: %ld\n",
+				fprintf(stdout, "ncurses version: %s, patch: %d\n",
 							NCURSES_VERSION,
 							NCURSES_VERSION_PATCH);
 


### PR DESCRIPTION
NCURSES_VERSION_PATCH is "int". This fixes this gcc warning:
```
src/pspg.c: In function ‘main’:
src/pspg.c:2020:52: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘int’ [-Wformat=]
     fprintf(stdout, "ncurses version: %s, patch: %ld\n",
                                                  ~~^
                                                  %d
```