### PR TITLE
fix ax_with_curses_extra to find <panel.h>

### DIFF
--- a/tools/m4_ax_with_curses_extra.m4
+++ b/tools/m4_ax_with_curses_extra.m4
@@ -212,6 +212,9 @@ AC_DEFUN([_AX_WITH_CURSES_EXTRA], [
     ], [
         AS_IF([test "x$ax_cv_curses_which" = xncursesw], [
             _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [ncursesw/$4], [$5])
+            AS_IF([test x$[]ax_cv_[]m4_tolower($1) != "xyes"], [
+                _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [$4], [$6])
+            ])
         ], [test "x$ax_cv_curses_which" = xncurses], [
             _AX_WITH_CURSES_CHECKEXTRA([$1], [$2], [$3], [$4], [$6])
             AS_IF([test x$[]ax_cv_[]m4_tolower($1) != "xyes"], [


### PR DESCRIPTION
These autohells macros do not find panel.h in the root of the library path when ncursesw variant is detected. This patch fixes the macros to search both ncursesw/ subdirectory and the root of the library path.

Based on https://github.com/crosstool-ng/crosstool-ng/blob/master/m4/ax_with_curses_extra.m4