### PR TITLE
Fix NCURSES_WIDECHAR preprocessor test

### DIFF
--- a/src/pspg.c
+++ b/src/pspg.c
@@ -1738,7 +1738,7 @@ get_event(MEVENT *mevent, bool *alt)
 
 #endif
 
-#if NCURSES_WIDECHAR > 0
+#if NCURSES_WIDECHAR > 0 && defined HAVE_NCURSESW
 
 	wint_t	ch;
 	int		ret;


### PR DESCRIPTION
A build from master failed for me because the type `wint_t` wasn't found. This type was referenced on line 1743, in an #if block predicated on the condition `NCURSES_WIDECHAR > 0`. The only time the variables defined in this block are referenced are also inside of an #if block, this time predicated by the additional condition `NCURSES_WIDECHAR > 0 && defined HAVE_NCURSESW`. It seems to be an error that this extra condition was omitted from the first preprocessor block.

My compiler version is: gcc (Ubuntu 5.4.0-6ubuntu1~16.04.11) 5.4.0 20160609

These are the ncurses libraries I have installed:

```
libncurses5/xenial,now 6.0+20160213-1ubuntu1 amd64 [installed]
libncurses5-dev/xenial,now 6.0+20160213-1ubuntu1 amd64 [installed]
libncursesw5/xenial,now 6.0+20160213-1ubuntu1 amd64 [installed]
ncurses-base/xenial,xenial,now 6.0+20160213-1ubuntu1 all [installed]
ncurses-bin/xenial,now 6.0+20160213-1ubuntu1 amd64 [installed]
ncurses-term/xenial,xenial,now 6.0+20160213-1ubuntu1 all [installed,automatic]
```

Here is the output of ./configure:

```
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for ANSI C header files... yes
checking whether termios.h defines TIOCGWINSZ... no
checking whether sys/ioctl.h defines TIOCGWINSZ... yes
checking for gcc... (cached) gcc
checking whether we are using the GNU C compiler... (cached) yes
checking whether gcc accepts -g... (cached) yes
checking for gcc option to accept ISO C89... (cached) none needed
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking for ncursesw via pkg-config... no
checking for ncursesw via fallback... 
checking for initscr() with -lncursesw... no
checking for ncurses via pkg-config... no
checking for ncurses via fallback... 
checking for initscr() with -lncurses... yes
checking for nodelay() with -lncurses... yes
checking for working ncurses/curses.h... no
checking for working ncurses.h... yes
checking for Curses Panel library with panel.h... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking for a readline compatible library... -lreadline
checking readline.h usability... no
checking readline.h presence... no
checking for readline.h... no
checking readline/readline.h usability... yes
checking readline/readline.h presence... yes
checking for readline/readline.h... yes
checking whether readline supports history... yes
checking history.h usability... no
checking history.h presence... no
checking for history.h... no
checking readline/history.h usability... yes
checking readline/history.h presence... yes
checking for readline/history.h... yes
configure: WARNING: The found ncurses library does not support wide-char.
configure: WARNING: This means that tig will not correctly render UTF-8.
checking for roundl in -lm... yes
checking for library containing clock_gettime... none required
configure: creating ./config.status
config.status: creating config.make
```