### PR TITLE
Makefile: Add CPPFLAGS to compile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,13 @@ endif
 all: pspg
 
 st_menu_styles.o: src/st_menu_styles.c config.make
-	$(CC) -O3 src/st_menu_styles.c -c $(CFLAGS)
-
+	$(CC) -O3 src/st_menu_styles.c -c $(CPPFLAGS) $(CFLAGS)
 
 st_menu.o: src/st_menu.c config.make
-	$(CC) -O3 src/st_menu.c -c $(CFLAGS)
+	$(CC) -O3 src/st_menu.c -c $(CPPFLAGS) $(CFLAGS)
 
 pspg: src/pspg.h src/unicode.h src/pspg.c src/unicode.c src/themes.c src/print.c src/config.c src/commands.h src/menu.c src/commands.c $(ST_MENU_OFILES) config.make
-	$(CC) -O3 src/pspg.c src/print.c src/unicode.c src/themes.c src/config.c src/menu.c src/commands.c $(ST_MENU_OFILES) -o pspg $(CFLAGS) $(LDFLAGS) $(LDLIBS)
+	$(CC) -O3 src/pspg.c src/print.c src/unicode.c src/themes.c src/config.c src/menu.c src/commands.c $(ST_MENU_OFILES) -o pspg $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(LDLIBS)
 
 clean:
 	$(RM) $(ST_MENU_OFILES)


### PR DESCRIPTION
Otherwise "-D_FORTIFY_SOURCE=2" is missing on Debian. Spotted by blhc (build log hardening check).

Possibly CPPFLAGS should be added to `config.make.in` as well, but the fix works even without it.