### PR TITLE
SIZE_MAX needs stdint.h

### DIFF
--- a/src/pretty-csv.c
+++ b/src/pretty-csv.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 #include "pspg.h"
 #include "unicode.h"


### PR DESCRIPTION
On FreeBSD 12.1-STABLE amd64:

```
src/pretty-csv.c:528:52: error: use of undeclared identifier 'SIZE_MAX'
                                                                width = utf_string_dsplen_multiline(field, SIZE_MAX, &_more_lines, true);
                                                                                                           ^
src/pretty-csv.c:532:42: error: use of undeclared identifier 'SIZE_MAX'
                                                                width = utf_string_dsplen(field, SIZE_MAX);
                                                                                                 ^
src/pretty-csv.c:974:79: error: use of undeclared identifier 'SIZE_MAX'
                                desc->headline_char_size = desc->maxx = utf_string_dsplen(desc->headline, SIZE_MAX);
                                                                                                          ^
3 errors generated.
```