### PR TITLE
fix syntax error, add missing semicolon

### DIFF
--- a/src/pgclient.c
+++ b/src/pgclient.c
@@ -301,7 +301,7 @@ pg_exec_query(Options *opts, RowBucketType *rb, PrintDataDesc *pdesc, const char
 
 #else
 
-	err = "Query cannot be executed. The Postgres library was not available at compile time."
+	err = "Query cannot be executed. The Postgres library was not available at compile time.";
 
 	return false;
 


### PR DESCRIPTION
Hi, I am the maintainer of https://ports.macports.org/port/pspg/summary

I was trying to upgrade the port version 2.5.0 and the source failed to compile, due to a missing semicolon.

In order to avoid maintaining a patch downstream, it would be very helpful to have a new point release with this fixed that I could upgrade to.

Thank you!