### PR TITLE
Unbreak FreeBSD build

### DIFF
--- a/src/pspg.c
+++ b/src/pspg.c
@@ -36,6 +36,7 @@
 #include <signal.h>
 #include <sys/ioctl.h>
 #include <poll.h>
+#include <stdint.h>
 
 #ifndef GWINSZ_IN_SYS_IOCTL
 #include <termios.h>
@@ -2652,7 +2653,7 @@ force_refresh_data:
 
 						memset(&desc2, 0, sizeof(desc2));
 
-						if (state.pathname)
+						if (state.pathname[0])
 						{
 							if (state.fp)
 							{


### PR DESCRIPTION
3.0.6 currently does not build on FreeBSD:

```
src/pspg.c:991:63: error: use of undeclared identifier 'SIZE_MAX'
                size_t prompt_dsplen = utf_string_dsplen(rl_display_prompt, SIZE_MAX);
```
^ This needs `stdint.h` include. There's also a warning:

```
src/pspg.c:2655:17: warning: address of array 'state.pathname' will always evaluate to 'true' [-Wpointer-bool-conversion]
                                                if (state.pathname)
                                                ~~  ~~~~~~^~~~~~~~
```
I'm not quite sure what would be the correct fix here, perhaps `if (state.pathname[0])`?