### PR TITLE
docs: fix simple typo, possition -> position

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -1034,7 +1034,7 @@ window_fill(int window_identifier,
 				i += trailing_spaces;
 			}
 
-			/* When we don't possition of last char, we can (for cursor draw) use 0 */
+			/* When we don't position of last char, we can (for cursor draw) use 0 */
 			i = i != -1 ? i : 0;
 
 			/* clean other chars on line */

--- a/src/st_menu.c
+++ b/src/st_menu.c
@@ -807,7 +807,7 @@ debug_print_size(WINDOW *window, char *name)
 #endif
 
 /*
- * adjust pulldown possition - move panels from ideal position to any position
+ * adjust pulldown position - move panels from ideal position to any position
  * where can be fully displayed.
  */
 static void


### PR DESCRIPTION
There is a small typo in src/print.c, src/st_menu.c.

Should read `position` rather than `possition`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md