### PR TITLE
Rename Presto SQL to Trino

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This pager can be used from the following clients command line clients too:
 - `sqlite`
 - [`pgcli`](https://github.com/dbcli/pgcli/)
 - `monetdb`
-- [`prestosql`](https://prestosql.io/)
+- [`Trino (formerly Presto SQL)`](https://trino.io/)
 
 ## Main target
 * possibility to freeze first few rows, first few columns


### PR DESCRIPTION
PrestoSQL was rebranded as Trino: https://trino.io/blog/2020/12/27/announcing-trino.html