### PR TITLE
SIZE_MAX needs stdint.h

### DIFF
--- a/src/export.c
+++ b/src/export.c
@@ -13,6 +13,7 @@
 
 #include <errno.h>
 #include <string.h>
+#include <stdint.h>
 
 #include "pspg.h"
 #include "commands.h"


### PR DESCRIPTION
`export.c` fails to build on FreeBSD without `stdint.h` include:
```
cc  src/st_menu_styles.c -c -I/usr/local/include -I/usr/local/include -isystem /usr/local/include -O2 -pipe  -fstack-protector-strong -isystem /usr/local/include -fno-strict-aliasing  -DCOMPILE_MENU   -D_GNU_SOURCE  -DPACKAGE_NAME=\"pspg\" -DPACKAGE_TARNAME=\"pspg\" -DPACKAGE_VERSION=\"0\" -DPACKAGE_STRING=\"pspg\ 0\" -DPACKAGE_BUGREPORT=\"pavel.stehule@gmail.com\" -DPACKAGE_URL=\"\" -DSTDC_HEADERS=1 -DHAVE_NCURSESW=1 -DHAVE_CURSES=1 -DHAVE_CURSES_ENHANCED=1 -DHAVE_CURSES_COLOR=1 -DHAVE_CURSES_OBSOLETE=1 -DHAVE_NCURSES_H=1 -DHAVE_PANEL=1 -DHAVE_PANEL_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_LIBREADLINE=1 -DHAVE_READLINE_READLINE_H=1 -DHAVE_READLINE_HISTORY=1 -DHAVE_READLINE_HISTORY_H=1 -DHAVE_POSTGRESQL=1 -DHAVE_LIBM=1 -DHAVE_SYS_INOTIFY_H=1 -DHAVE_INOTIFY=1 -Wall -MD
src/export.c:780:62: error: use of undeclared identifier 'SIZE_MAX'
                                                                indent_spaces = utf_string_dsplen(quoted_table_name, SIZE_MAX) + 1 + 12;
                                                                                                                     ^
1 error generated.
```