### PR TITLE
Add usql to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This pager can be used from the following clients command line clients too:
 - [`pgcli`](https://github.com/dbcli/pgcli/)
 - `monetdb`
 - [`Trino (formerly Presto SQL)`](https://trino.io/)
+- [`usql`](https://github.com/xo/usql/)
 
 
 ## Main target


### PR DESCRIPTION
`usql` [0.9.0](https://github.com/xo/usql/releases/tag/v0.9.0) has just been released, with support for a pager. It should work great with `pspg`.

`usql` is a universal SQL client, modeled after `psql` but it works with almost any databases that have a Go driver implementing the `database/sql` interface.