### PR TITLE
change the install instruction for OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,9 +638,8 @@ Use the AUR helper of your choice or git and `makepkg` to install pspg.
 
 ## OpenBSD
 
-    % cd /usr/ports/databases/pspg
-    % doas make install
-    
+    # pkg_add pspg
+
 [More about it](https://fluca1978.github.io/2021/10/28/pspgOpenBSD.html)
 
 ## Using MacPorts (MacOS only)


### PR DESCRIPTION
Using the pre-compiled binary packages is the encouraged way to install programs on OpenBSD.

+cc @fluca1978, thanks for adding them in the first place! :-)
