### PR TITLE
replace sprintf with snprintf

### DIFF
--- a/src/pgclient.c
+++ b/src/pgclient.c
@@ -275,7 +275,8 @@ pg_exec_query(Options *opts, char *query, RowBucketType *rb, PrintDataDesc *pdes
 	/* Check to see that the backend connection was successfully made */
 	if (PQstatus(conn) != CONNECTION_OK)
 	{
-		sprintf(errmsg, "Connection to database failed: %s", PQerrorMessage(conn));
+		snprintf(errmsg, sizeof(errmsg),
+		    "Connection to database failed: %s", PQerrorMessage(conn));
 		RELEASE_AND_LEAVE(errmsg);
 	}
 
@@ -286,7 +287,8 @@ pg_exec_query(Options *opts, char *query, RowBucketType *rb, PrintDataDesc *pdes
 	result = PQexec(conn, query);
 	if (PQresultStatus(result) != PGRES_TUPLES_OK)
 	{
-		sprintf(errmsg, "Query doesn't return data: %s", PQerrorMessage(conn));
+		snprintf(errmsg, sizeof(errmsg),
+		    "Query doesn't return data: %s", PQerrorMessage(conn));
 		RELEASE_AND_LEAVE(errmsg);
 	}
 

--- a/src/pspg.c
+++ b/src/pspg.c
@@ -4265,7 +4265,8 @@ reset_search:
 						{
 							char	buffer[256];
 
-							sprintf(buffer, "only color schemas 0..%d are supported", MAX_STYLE);
+							snprintf(buffer, sizeof(buffer),
+							    "only color schemas 0..%d are supported", MAX_STYLE);
 
 							show_info_wait(buffer, NULL, true, true, false, true);
 							break;


### PR DESCRIPTION
Hello,

straightforwardly, this replaces some `sprintf` with a bounded `snprintf`.  It was brought to my attention by the linker on OpenBSD:

```
pspg.c(pspg.o:(main)): warning: sprintf() is often misused, please use snprintf()
```