### PR TITLE
Declare minimum required autoconf version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,3 +1,4 @@
+AC_PREREQ([2.70])
 AC_INIT([pspg],[0],[pavel.stehule@gmail.com],[pspg])
 
 AC_LANG([C])


### PR DESCRIPTION
This improves error message from autogen.sh when autoconf is too old.

Before:

```console
$ ./autogen.sh
configure.ac:12: error: possibly undefined macro: AC_CHECK_INCLUDES_DEFAULT
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
```

After:

```console
$ ./autogen.sh
configure.ac:1: error: Autoconf version 2.70 or higher is required
configure.ac:1: the top level
autom4te: /usr/bin/m4 failed with exit status: 63
aclocal: error: echo failed with exit status: 63
```