### PR TITLE
Fix for issue #228.

### DIFF
--- a/scripts/sqlcl/pspg.sql
+++ b/scripts/sqlcl/pspg.sql
@@ -35,6 +35,7 @@ cmd.handle = function (conn,ctx,cmd) {
 
       // Set this to a big value so that we do not get repeating headers
       ctx.putProperty("script.runner.setpagesize", 1000000);
+      sqlcl.setConn(conn);
       sqlcl.setStmt(sql);
       sqlcl.run();
 


### PR DESCRIPTION
If sqlcl is started with `/nolog` argument and the `connect` command is used afterwards, `pspg` fails as described in issue #228. If you connect directly using a connect string provided as an argument, `pspg` is working for the current session only. As soon as a new `connect` is issued, all subsequent `pspg` command will fail with `SQL Error: Closed Connection`.

This patch ensures that the current sqlcl connection handler is always assigned to the sqlcl executor.