### PR TITLE
Fix OOB Access in pb_print_rowbuckets

### DIFF
--- a/src/pretty-csv.c
+++ b/src/pretty-csv.c
@@ -526,6 +526,10 @@ pb_print_rowbuckets(PrintbufType *printbuf,
 				   PrintDataDesc *pdesc,
 				   char *title)
 {
+	if (pdesc->nfields == 0) {
+		/* Early return to avoid OOB access in the next line */
+		return;	
+	}	
 	bool		is_last_column_multiline = pdesc->multilines[pdesc->nfields - 1];
 	int			last_column_num = pdesc->nfields - 1;
 	int			printed_rows = 0;


### PR DESCRIPTION
## Description of the OOB Bug

`pb_print_rowbuckets` can be called even if `pdesc` is properly not initialized in the call to `prepare_pdesc`. This can leave the `nfields` to be 0 causing a 1 byte OOB in the `pb_print_rowbuckets`.